### PR TITLE
feat(abbreviate-number): update abbreviate number output to two decimal places instead of one

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -355,10 +355,10 @@ Arguments
 |`number`|`number`|`true`|The number to be abbreviated|
 
 Examples
-* Numbers below 1,000 are displayed without abbreviation
-* Numbers between 1,000 and 1,000,000 are displayed in thousands (e.g. 1.23k)
-* Numbers between 1,000,000 and 1,000,000,000 are displayed in millions (e.g. 1.23M)
-* Numbers above 1,000,000,000 are displayed in billions (e.g. 1.23B)
+- Numbers below 1,000 are displayed without abbreviation
+- Numbers between 1,000 and 1,000,000 are displayed in thousands (e.g. 1.23K)
+- Numbers between 1,000,000 and 1,000,000,000 are displayed in millions (e.g. 1.23M)
+- Numbers above 1,000,000,000 are displayed in billions (e.g. 1.23B)
 
 Note: If the input `number` is null or undefined, the function returns null.
 

--- a/README.MD
+++ b/README.MD
@@ -347,13 +347,20 @@ Arguments
 
 ## `TextHelpers.abbreviateNumber(number)`
 
-Abbreviate number
-Returns the string representation of the abbreviated number
+Returns the string representation of the abbreviated number, rounded to two decimal places.
 
 Arguments
 |Name|Type|Required|Description|
 |--|--|--|--|
 |`number`|`number`|`true`|The number to be abbreviated|
+
+Examples
+* Numbers below 1,000 are displayed without abbreviation
+* Numbers between 1,000 and 1,000,000 are displayed in thousands (e.g. 1.23k)
+* Numbers between 1,000,000 and 1,000,000,000 are displayed in millions (e.g. 1.23M)
+* Numbers above 1,000,000,000 are displayed in billions (e.g. 1.23B)
+
+Note: If the input `number` is null or undefined, the function returns null.
 
 # ObjectHelpers
 

--- a/__tests__/text.test.ts
+++ b/__tests__/text.test.ts
@@ -509,18 +509,18 @@ it("abbreviateNumber", () => {
   expect(actual).toBe(expected)
 
   actual = abbreviateNumber(2980)
-  expected = "3k"
+  expected = "3.00k"
   expect(actual).toBe(expected)
 
   actual = abbreviateNumber(29800)
-  expected = "29.8k"
+  expected = "29.80k"
   expect(actual).toBe(expected)
 
   actual = abbreviateNumber(123456789)
-  expected = "123.5M"
+  expected = "123.46M"
   expect(actual).toBe(expected)
 
   actual = abbreviateNumber(1234567890)
-  expected = "1.2B"
+  expected = "1.23B"
   expect(actual).toBe(expected)
 })

--- a/__tests__/text.test.ts
+++ b/__tests__/text.test.ts
@@ -509,7 +509,7 @@ it("abbreviateNumber", () => {
   expect(actual).toBe(expected)
 
   actual = abbreviateNumber(2980)
-  expected = "3.00k"
+  expected = "29.80k"
   expect(actual).toBe(expected)
 
   actual = abbreviateNumber(29800)

--- a/__tests__/text.test.ts
+++ b/__tests__/text.test.ts
@@ -509,11 +509,11 @@ it("abbreviateNumber", () => {
   expect(actual).toBe(expected)
 
   actual = abbreviateNumber(2980)
-  expected = "29.80k"
+  expected = "2.98K"
   expect(actual).toBe(expected)
 
   actual = abbreviateNumber(29800)
-  expected = "29.80k"
+  expected = "29.80K"
   expect(actual).toBe(expected)
 
   actual = abbreviateNumber(123456789)

--- a/src/text.ts
+++ b/src/text.ts
@@ -315,7 +315,7 @@ export const abbreviateNumber = (number: number | undefined | null): string | nu
 
   if (abbreviated) {
     const { value, symbol } = abbreviated
-    return (number / value).toFixed(1).replace(/\.0$/, "") + symbol
+    return (number / value).toFixed(2).replace(/\.00$/, "") + symbol
   }
 
   return number.toString()

--- a/src/text.ts
+++ b/src/text.ts
@@ -306,7 +306,7 @@ export const abbreviateNumber = (number: number | undefined | null): string | nu
   const abbreviations = [
     { value: 1e9, symbol: "B" },
     { value: 1e6, symbol: "M" },
-    { value: 1e3, symbol: "k" },
+    { value: 1e3, symbol: "K" },
   ]
 
   if (!number || isNaN(number)) return null


### PR DESCRIPTION
### Short Summary

### Screenshots

### Util in use (before):
![image](https://github.com/user-attachments/assets/3b3c7253-b3c8-42ae-9057-6aaa04e3be32)

### Util in use (after):
![image](https://github.com/user-attachments/assets/ab04f458-b13e-4ec1-946d-86f201b674ab)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the `abbreviateNumber` function to display numbers with two decimal places for improved clarity.

- **Bug Fixes**
	- Updated expected outputs in tests to reflect the new formatting of the `abbreviateNumber` function.

- **Documentation**
	- Improved descriptions and examples for various helper methods to enhance user understanding and type safety.

- **Tests**
	- Expanded and refined test cases for utility functions, ensuring comprehensive coverage and validation of expected behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->