### PR TITLE
fix(text helpers): address issue where convertCamelCaseToReadableText splits acronyms

### DIFF
--- a/__tests__/text.test.ts
+++ b/__tests__/text.test.ts
@@ -17,6 +17,7 @@ import {
   isValidEmail,
   convertCamelToKebabCase,
   convertKebabToCamelCase,
+  convertCamelCaseToReadableText,
   isAcronym,
   acronymToKebabCase,
   generateIDFromWord,
@@ -457,6 +458,40 @@ it("convertKebabToCamelCase", () => {
 
   actual = convertKebabToCamelCase("test-with-number5")
   expected = "TestWithNumber5"
+  expect(actual).toBe(expected)
+})
+
+it("convertCamelCaseToReadableText", () => {
+  let actual = convertCamelCaseToReadableText("XMLHttpRequest")
+  let expected = "XML Http Request"
+  expect(actual).toBe(expected)
+
+  actual = convertCamelCaseToReadableText("getURLForID")
+  expected = "Get URL For ID"
+  expect(actual).toBe(expected)
+
+  actual = convertCamelCaseToReadableText("userName")
+  expected = "User Name"
+  expect(actual).toBe(expected)
+
+  // Edge case: single word
+  actual = convertCamelCaseToReadableText("name")
+  expected = "Name"
+  expect(actual).toBe(expected)
+
+  // Edge case: empty string
+  actual = convertCamelCaseToReadableText("")
+  expected = ""
+  expect(actual).toBe(expected)
+
+  // Edge case: numbers mixed with letters
+  actual = convertCamelCaseToReadableText("user123Name")
+  expected = "User123 Name"
+  expect(actual).toBe(expected)
+
+  // Edge case: already starts with capital
+  actual = convertCamelCaseToReadableText("FirstName")
+  expected = "First Name"
   expect(actual).toBe(expected)
 })
 

--- a/src/text.ts
+++ b/src/text.ts
@@ -179,8 +179,9 @@ export function convertKebabToCamelCase(word: string): string {
  */
 export function convertCamelCaseToReadableText(name: string): string {
   return name
-    .replace(/([A-Z])/g, " $1")
-    .replace(/^./, (str) => str.toUpperCase())
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .replace(/([a-z\d])([A-Z])/g, "$1 $2")
+    .replace(/^./, (c) => c.toUpperCase())
     .trim()
 }
 


### PR DESCRIPTION
### Short Summary
Address issue where convertCamelCaseToReadableText splits acronyms 

### Screenshots
Before
--------
<img width="890" height="215" alt="Screenshot 2025-09-19 at 5 53 02 PM" src="https://github.com/user-attachments/assets/de84c346-6b37-4e02-a291-5a71a220eb92" />

After 
--------
<img width="887" height="254" alt="Screenshot 2025-09-19 at 5 53 58 PM" src="https://github.com/user-attachments/assets/4977916b-4fd1-4ce2-89c8-dcb0045debb3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved readability of auto-generated labels by more accurately splitting CamelCase and preserving acronyms (e.g., HTMLParser → HTML Parser, userName → User Name).
  - Better handling of digits within words and capitalization for cleaner display (e.g., user123Name → User123 Name).
- Tests
  - Added comprehensive test coverage for text formatting, including acronyms, digit boundaries, edge cases (empty strings, single words), and capitalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->