### PR TITLE
chore(release): enhance release workflow with 1 password environment variables and timeout

### DIFF
--- a/.github/workflows/release_package.yml
+++ b/.github/workflows/release_package.yml
@@ -19,14 +19,24 @@ concurrency:
 
 jobs:
   release:
+    environment: production
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     permissions:
       contents: write
       packages: write
       pull-requests: write
-
     steps:
+      - name: Load Environment Variables From 1Password
+        id: op-env
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          GH_TOKEN: ${{vars.OP_VAULT_REF}}/GH_TOKEN
+          NPM_TOKEN: ${{vars.OP_VAULT_REF}}/NPM_TOKEN
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
@@ -39,8 +49,8 @@ jobs:
       - uses: codfish/semantic-release-action@v3
         id: semantic
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ env.GH_TOKEN }}
+          NPM_TOKEN: ${{ env.NPM_TOKEN }}
 
       - name: Release Version
         run: echo ${{ steps.semantic.outputs.release-version }}


### PR DESCRIPTION
- Added production environment specification for the release job
- Set timeout for the release job to 30 minutes
- Integrated loading of environment variables from 1Password for secure token management

### Short Summary

### Screenshots