### PR TITLE
chore(ci): pin external workflow actions

### DIFF
--- a/.github/workflows/check_pr_title_style.yml
+++ b/.github/workflows/check_pr_title_style.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: read
       statuses: write
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017  # Using 5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release_package.yml
+++ b/.github/workflows/release_package.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Load Environment Variables From 1Password
         id: op-env
-        uses: 1password/load-secrets-action@v3
+        uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6  # Using 3.0.0
         with:
           export-env: true
         env:
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: npm clean-install
 
-      - uses: codfish/semantic-release-action@v3
+      - uses: codfish/semantic-release-action@b621d34fabe0940f031e89b6ebfea28322892a10  # Using 3.5.0
         id: semantic
         env:
           GITHUB_TOKEN: ${{ steps.op-env.outputs.GH_TOKEN }}


### PR DESCRIPTION
This PR updates GitHub Actions workflows to:

1. Pin external actions to specific commit hashes for better security and reproducibility

**Files changed:**
- .github/workflows/check_pr_title_style.yml
- .github/workflows/release_package.yml
