### PR TITLE
ci(release): configure GPG signing for semantic-release commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,15 @@ jobs:
       - checkout
       - node/install:
           node-version: "22"
+      - run:
+          name: Import GPG key and configure git signing
+          command: |
+            echo "$GPG_PRIVATE_KEY" | base64 --decode | gpg --batch --import
+            git config --global user.signingkey 65C0CE72
+            git config --global commit.gpgsign true
+            git config --global tag.gpgsign true
+            git config --global user.name "Akadenia CI Bot"
+            git config --global user.email "ci@akadenia.com"
       - node/install-packages:
           pkg-manager: npm
       - run: npm run build


### PR DESCRIPTION
## What

Configures GPG commit signing in the CircleCI release job so that commits and tags created by semantic-release are signed.

## Why

Branch protection on `main` now requires signed commits (added in #69). The `@semantic-release/git` plugin pushes a `chore(release)` commit back to `main`, which was being rejected because it wasn't signed.

## How

- Imports a GPG private key (base64-encoded from `GPG_PRIVATE_KEY` env var) in the release job
- Configures git to sign all commits and tags with the CI bot key (`65C0CE72`)
- Sets git user to `Akadenia CI Bot <ci@akadenia.com>`

## Required Setup

1. **CircleCI:** Add `GPG_PRIVATE_KEY` to the `npm-publish` context (base64-encoded private key)
2. **GitHub:** Add the corresponding GPG public key to the account/bot that pushes releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured release pipeline to cryptographically sign commits and tags using GPG, enhancing the security and authenticity of release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->