### PR TITLE
fix: unify CI scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           pkg-manager: pnpm
       - run: pnpm build
       - run: pnpm lint
-      - run: pnpm run --if-present test
+      - run: pnpm test
 
   build_lint_test:
     docker:


### PR DESCRIPTION
## Summary
- Use consistent test command (pnpm test) for all packages instead of conditional
- Use GH_TOKEN consistently for GitHub API access (was using GITHUB_TOKEN)
- AkadeniaAzureStorage retains test:with-azurite for Azure Blob Storage testing

## Test plan
- [ ] CI workflows execute successfully on all packages
- [ ] Release job creates PRs with correct token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI test step to run the project’s test command directly during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->